### PR TITLE
Good practices on > and < operations

### DIFF
--- a/benchmarks/example5.ipynb
+++ b/benchmarks/example5.ipynb
@@ -60,7 +60,7 @@
     "        opposites = (dimuons.i0.charge != dimuons.i1.charge)\n",
     "        \n",
     "        # Get only muons with energy between 60 and 120.\n",
-    "        limits = (dimuons.mass > 60) & (dimuons.mass < 120)\n",
+    "        limits = (dimuons.mass >= 60) & (dimuons.mass < 120)\n",
     "        \n",
     "        # Mask the dimuons with the opposites and the limits to get dimuons with opposite charge and mass between 60 and 120 GeV.\n",
     "        good_dimuons = dimuons[opposites & limits]\n",


### PR DESCRIPTION
Educational note: when histograms are filled, it's typical that a given bin contains entries that are greater than *or equal to* the lower bin boundary and less then (but not equal to!) the upper bin boundary.  I've adjusted the mass window to reflect that (even though admittedly the problem statement was vague on this point).